### PR TITLE
Remove Google Guava dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -205,11 +205,6 @@
             <scope>compile</scope>
         </dependency>
         <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-            <version>29.0-jre</version>
-        </dependency>
-        <dependency>
             <groupId>com.ibm.icu</groupId>
             <artifactId>icu4j</artifactId>
             <version>67.1</version>


### PR DESCRIPTION
We use Google Guava to dynamically discover our keyword implementations. Shall we use the plain java approach as described at https://dzone.com/articles/get-all-classes-within-package ?